### PR TITLE
Added build instructions for Ubuntu 16.04 and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,97 @@
+FROM ubuntu:xenial
+WORKDIR /data/wallet
+
+RUN apt update
+RUN apt install -y zip unzip curl gcc g++ make wget git
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt update
+RUN apt-get install -y nodejs
+
+RUN apt-get install -y default-jdk
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+RUN unzip commandlinetools-linux-6609375_latest.zip
+
+RUN npm install -g ionic@5.2.1 cordova@9
+RUN echo "y" | npm install -g @angular/cli@8.2
+
+RUN mkdir /usr/local/sdk
+RUN mv tools /usr/local/sdk/tools
+ENV ANDROID_SDK_ROOT=/usr/local/sdk
+ENV ANDROID_HOME=/usr/local/sdk
+
+RUN echo "y" | /usr/local/sdk/tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "tools"
+RUN /usr/local/sdk/tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "build-tools;28.0.3"
+
+# We need to install a version of gradle to allow Cordova to set the gradle wrapper
+# The actual version does not really matter apparently, as Cordova will download
+# its own gradle version anyway. This mentions version 4.10.3, but 6.6.1 works as well
+RUN curl -s "https://get.sdkman.io" | /bin/bash
+RUN echo "#~/bin/bash\n\
+source $HOME/.sdkman/bin/sdkman-init.sh\n\
+sdk install gradle 4.10.3" | sed 's/~/!/' > $HOME/installgradle
+RUN chmod a+x $HOME/installgradle
+RUN $HOME/installgradle
+
+# Here we create a new ionic/cordova project for the sole purpose of forcing 
+# Cordova to pre-install it's version of gradle. This prevents the build process
+# from having to download the gradle version each time you want to build a new
+# android version
+RUN echo "#~/bin/bash\n\
+cd /root\n\
+ionic start Test blank --cordova\n\
+cd /root/Test\n\
+\n\
+source /root/.sdkman/bin/sdkman-init.sh\n\
+export PATH=/root/.sdkman/candidates/gradle/current/bin:$PATH\n\
+\n\
+ionic cordova build android\n\
+cd /root && rm -rf Test" | sed 's/~/!/' > $HOME/preinstallgradle
+RUN chmod a+x $HOME/preinstallgradle
+RUN $HOME/preinstallgradle
+
+ENTRYPOINT ["/usr/local/bin/alastria"]
+CMD ["init"]
+
+RUN echo "#~/bin/bash\n\
+set -e\n\
+echo \"\$@\"\n\
+source /root/.sdkman/bin/sdkman-init.sh\n\
+export PATH=/root/.sdkman/candidates/gradle/current/bin:$PATH\n\
+\n\
+cd /data/wallet\n\
+case \$1 in\n\
+wait)\n\
+    sleep \$2\n\
+    ;;\n\
+init)\n\
+    npm install\n\
+\n\
+    cd node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs\n\
+    cat browser.js | sed 's/^\(.*\)node: false\(.*\)\$/\\1node: { crypto: true, stream: true, buffer:true }\\2/' > tmp\n\
+    mv tmp browser.js\n\
+    cd /data/wallet\n\
+    ;;\n\
+i*)\n\
+    # ionic command\n\
+    shift 1\n\
+    exec ionic \"\$@\"\n\
+    ;;\n\
+ng)\n\
+    # angular command\n\
+    shift 1\n\
+    exec ng \"\$@\"\n\
+    ;;\n\
+npm)\n\
+    # node package manager command\n\
+    shift 1\n\
+    exec npm \"\$@\"\n\
+    ;;\n\
+*)\n\
+    echo \"Unrecognised command \$1\"\n\
+    ;;\n\
+esac\n\
+" | sed 's/~/!/' > /usr/local/bin/alastria
+
+RUN chmod a+x /usr/local/bin/alastria
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Example mobile application to implement Alastria user stories
 
 ## Starting 🚀
 
-These instructions will allow you to get a copy of the project running on your local machine for development and testing purposes:
+These general instructions will allow you to get a copy of the project running on your local machine for development and testing purposes. For instructions for specific operating systems, see:
+* [Docker](doc/install_docker.md)
+* [Ubuntu 16.04 LTS](doc/install_ubuntu1604.md)
 
-Clone the proyect:
+Clone the project:
 ```
 git clone https://github.com/alastria/alastria-wallet.git
 ```

--- a/doc/install_docker.md
+++ b/doc/install_docker.md
@@ -1,0 +1,40 @@
+# Install build environment using Docker
+
+## Prerequisites
+Install the Docker container services using your favorite package manager.
+
+Copy the Dockerfile to a different build directory, to avoid passing the entire wallet directory content to the docker build environment as context.
+```
+cp Dockerfile <buildlocation>
+cd <buildlocation>
+```
+
+Then build the docker image using the Dockerfile:
+```
+docker build .
+```
+Tag the build result, naming it 'alastria':
+```
+IMGID=`docker images -a | head -2 | tail -1 | awk '{print $3}'`
+docker tag $IMGID alastria
+```
+
+## Running the docker container
+The Docker container supplies a shell interface to access the NPM, Angular and Ionic build tools. It also has a default 'init' command that initialises the NPM modules and (tries to) adjust an angular build file as per the README documentation. Run the following command from the wallet repository:
+```
+docker run -v <wallet repository>:/data/wallet alastria
+```
+
+This will execute an `npm install` on the current wallet repository and checkout the alastria-identity subrepository.
+
+Specifying either the `npm`, `ng` or `ionic` build environment will allow you to pass arguments to those build tools. For example, from inside the alastria-wallet repository:
+```
+docker run -v `pwd`:/data/wallet alastria npm install
+docker run -v `pwd`:/data/wallet alastria ng build --prod --watch
+docker run -v `pwd`:/data/wallet alastria ionic cordova build android
+```
+
+The last command will build an Android package that can be installed on an emulator.
+
+## Docker runtime options
+The build process takes quite some memory and CPU power. Specify `-m 4g` to set the docker memory limit to 4Gigabyte. Specify `--cpus=2` to allow the use of at least 2 cpus. These are recommended minimum settings for a timely build. Using less than 2Gigabyte will cause the build to fail.

--- a/doc/install_ubuntu1604.md
+++ b/doc/install_ubuntu1604.md
@@ -1,0 +1,84 @@
+# AlastriaID Wallet Installation
+
+These instructions are for installing and compiling the AlastriaID wallet code on Ubuntu 16.04 LTS.
+The end-result is an APK file that you can upload to your Android emulator.
+
+We assume a vanilla Ubuntu 16.04 environment without other tooling, like a freshly setup installation.
+For information on how to setup a virtual server, please refer to documentation on Vagrant, VirtualBox
+and other virtualisation platforms. The compilation process requires at least a 2Gb, 2CPU environment.
+
+We're installing Node@10, Ionic@5.2.1, Cordova@9 and Angular@8.2
+The original installation says Node@8+, but Angular@8.2 requires Node@10.
+For Android, we take the latest version at the time of writing.
+
+## Basic build tools
+```
+sudo apt install git zip unzip -y
+
+curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+sudo bash nodesource_setup.sh
+sudo apt-get install -y nodejs
+sudo apt-get install -y gcc g++ make
+sudo apt-get install -y default-jdk
+```
+
+## Install Android build tools
+```
+cd $HOME
+wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+unzip commandlinetools-linux-6609375_latest.zip
+
+mkdir sdk
+mv commandlinetools-linux-6609375 sdk/tools
+export ANDROID_SDK_ROOT=$HOME/sdk
+export ANDROID_HOME=$HOME/sdk
+export PATH=$PATH:$HOME/sdk/tools/bin
+sdkmanager --sdk_root=$ANDROID_SDK_ROOT "tools"
+sdkmanager --sdk_root=$ANDROID_SDK_ROOT 'platform-tools'
+sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-30"
+sdkmanager --sdk_root=$ANDROID_SDK_ROOT "build-tools;30.0.2"
+sdkmanager --sdk_root=$ANDROID_SDK_ROOT "cmdline-tools;latest"
+```
+
+## Install Gradle
+```
+curl -s "https://get.sdkman.io" | bash
+source "/home/michiel/.sdkman/bin/sdkman-init.sh"
+sdk install gradle 6.6.1
+```
+
+## Install Wallet build tools
+```
+sudo npm install -g ionic@5.2.1 cordova@9
+sudo npm install -g @angular/cli@8.2
+sudo npm install -g native-run
+
+# the following is necessary due to a bug in this version of NPM 
+sudo chown `id -u`:`id -g` -R ~/.npm
+sudo chown `id -u`:`id -g` -R ~/.config
+```
+
+## Wallet Installation
+```
+cd $HOME
+git clone https://github.com/alastria/alastria-wallet.git
+
+cd alastria-wallet
+npm install
+ 
+# see: https://github.com/auth0/node-jsonwebtoken/issues/471#issuecomment-398798497
+# change the file
+# At the bottom, change
+#    node: false
+# to
+#    node: { crypto: true, stream: true, buffer:true },
+cd node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs
+cat browser.js | sed 's/^\(.*\)node: false\(.*\)$/\1node: { crypto: true, stream: true, buffer:true }\2/' > tmp
+mv tmp browser.js
+cd $HOME/alastria-wallet
+```
+
+## Build the Wallet
+```
+ionic cordova run android --no-native-run
+```


### PR DESCRIPTION
This PR adds a doc directory containing build instructions for a basic Ubuntu 16.04 LTS platform.

It also contains a Dockerfile that sets up a build environment for the wallet based on the Ubuntu 16.04 instructions, containing an entry point script that allows the user to execute various build commands at the installed toolset (npm, ng, ionic). Using this docker, users can easily build Android files based on the wallet configurations.
I did not test this for XCode compatibility.

Work gratefully sponsored by SURFnet, Netherlands, https://surf.nl